### PR TITLE
modify rustvisitor to make development <-> testing loop easier

### DIFF
--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -155,7 +155,7 @@ class RustVisitor {
         console.log('entering visitModelManager');
 
         // Create the "lib.rs" file containing the module references.
-        const fileName = `lib.rs`;
+        const fileName = `mod.rs`;
         parameters.fileWriter.openFile(fileName);
         for (const namespace of modelManager.getNamespaces()) {
             const namespaceFileName = this.toValidRustName(namespace);
@@ -199,10 +199,10 @@ class RustVisitor {
             .filter(namespace => namespace !== modelFile.getNamespace()) // Skip own namespace.
             .filter((v, i, a) => a.indexOf(v) === i) // Remove any duplicates from direct imports
             .forEach(namespace => {
-                parameters.fileWriter.writeLine(0, `use crate::${this.toValidRustName(namespace)}::*;`);
+                parameters.fileWriter.writeLine(0, `use crate::lib::${this.toValidRustName(namespace)}::*;`);
             });
 
-        parameters.fileWriter.writeLine(0, `use crate::utils::*;`);
+        parameters.fileWriter.writeLine(0, `use crate::lib::utils::*;`);
 
         parameters.fileWriter.writeLine(1, '');
 


### PR DESCRIPTION
this PR helps to test the output generated by [lib/codgen/rustvisitor.js ](https://github.com/beNEXT-io/concerto-codegen/blob/main/lib/codegen/fromcto/rust/rustvisitor.js) inside [accord-helloworld-app](https://github.com/beNEXT-io/accord-helloworld-app)