### PR TITLE
add datetime compatibility for UTC and UTC (+ or -) hours

### DIFF
--- a/lib/codegen/fromcto/rust/rustvisitor.js
+++ b/lib/codegen/fromcto/rust/rustvisitor.js
@@ -392,7 +392,7 @@ class RustVisitor {
         parameters.fileWriter.writeLine(0, 'where')
         parameters.fileWriter.writeLine(1, 'S: Serializer,')
         parameters.fileWriter.writeLine(0, '{')
-        parameters.fileWriter.writeLine(1, 'let datetime_str = datetime.format("%Y-%m-%dT%H:%M:%S%.3fZ").to_string();')
+        parameters.fileWriter.writeLine(1, 'let datetime_str = datetime.format("%+").to_string();')
         parameters.fileWriter.writeLine(1, 'serializer.serialize_str(&datetime_str)')
         parameters.fileWriter.writeLine(0, '}')
         parameters.fileWriter.closeFile()


### PR DESCRIPTION
This change adds datetime serialization for including datetime formats like the following :
- `2021-04-27T13:10:12.792-04:00`
- `2023-04-12T08:40:26.112Z`